### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,59 +1,60 @@
-{"Registrations":
-  [ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/microsoft/Microsoft-Rocketbox", 
-         "commitHash": "8bae73a8e96e3cd5d550e0592e01d99b8386ec4a" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/Microsoft-Rocketbox",
+          "commitHash": "8bae73a8e96e3cd5d550e0592e01d99b8386ec4a"
+        }
+      }
     },
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/microsoft/MixedReality-WebRTC", 
-         "commitHash": "8666f367e61fd478be5433b01939695a33f81d5b" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/MixedReality-WebRTC",
+          "commitHash": "8666f367e61fd478be5433b01939695a33f81d5b"
+        }
+      }
     },
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v1.5.7.0", 
-         "commitHash": "731dd0f0580587362e9e9782fe6699d53d407f08" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v1.5.7.0",
+          "commitHash": "731dd0f0580587362e9e9782fe6699d53d407f08"
+        }
+      }
     },
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/qian256/HoloLensARToolKit", 
-         "commitHash": "6d3560739dbab6cdb8a22396092a4cf3554bb0fc" 
-         }
-       }
-    },
-    {
-      "Component": {
-         "Type": "NuGet",
-         "NuGet": {
-           "Name": "Newtonsoft.Json",
-           "Version": "8.0.3"
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/qian256/HoloLensARToolKit",
+          "commitHash": "6d3560739dbab6cdb8a22396092a4cf3554bb0fc"
+        }
+      }
     },
     {
       "Component": {
-         "Type": "NuGet",
-         "NuGet": {
-           "Name": "InputSimulator",
-           "Version": "1.0.4"
-         }
-       }
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "Newtonsoft.Json",
+          "Version": "8.0.3"
+        }
+      }
     },
+    {
+      "Component": {
+        "Type": "NuGet",
+        "NuGet": {
+          "Name": "InputSimulator",
+          "Version": "1.0.4"
+        }
+      }
+    }
   ],
   "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.